### PR TITLE
Ignores multiple spaces for word count to prevent false positives

### DIFF
--- a/js/miniCount.js
+++ b/js/miniCount.js
@@ -21,7 +21,7 @@ jQuery(function() {
     state = '';
     patterns = {
       character: /./g,
-      word: /\s|$/g,
+      word: /\s+|$/g,
       sentence: /(\S.+?[.!?])(?=\s+|$)/g
     };
     this.settings = {};


### PR DESCRIPTION
miniCount will falsely count every extra space as a word.  

For example, if someone types "bob jones" that counts as 2 words, but if someone types "bob   jones" that will count as 4 words.  This adjusts the RegEx so that it works properly with spaces.
